### PR TITLE
SERVER-122483 Fix include ordering for ToCharsCompat.h

### DIFF
--- a/js/src/jsnum.cpp
+++ b/js/src/jsnum.cpp
@@ -27,8 +27,6 @@
 #include <string.h>  // memmove
 #include <string_view>
 
-#include "util/ToCharsCompat.h"  // MONGODB MODIFICATION: MONGO_MOZJS_TO_CHARS
-
 #include "jstypes.h"
 
 #include "builtin/String.h"
@@ -47,6 +45,7 @@
 #include "util/DoubleToString.h"
 #include "util/Memory.h"
 #include "util/StringBuilder.h"
+#include "util/ToCharsCompat.h"  // MONGODB MODIFICATION: MONGO_MOZJS_TO_CHARS
 #include "vm/BigIntType.h"
 #include "vm/GlobalObject.h"
 #include "vm/JSAtomUtils.h"  // Atomize, AtomizeString

--- a/js/src/vm/BigIntType.cpp
+++ b/js/src/vm/BigIntType.cpp
@@ -97,8 +97,6 @@
 #include <memory>
 #include <type_traits>  // std::is_same_v
 
-#include "util/ToCharsCompat.h"  // MONGODB MODIFICATION: MONGO_MOZJS_TO_CHARS
-
 #include "jsnum.h"
 
 #include "gc/GCEnum.h"
@@ -109,6 +107,7 @@
 #include "js/Utility.h"
 #include "util/CheckedArithmetic.h"
 #include "util/DifferentialTesting.h"
+#include "util/ToCharsCompat.h"  // MONGODB MODIFICATION: MONGO_MOZJS_TO_CHARS
 #include "vm/JSONPrinter.h"  // js::JSONPrinter
 #include "vm/StaticStrings.h"
 

--- a/js/src/vm/JSAtomUtils.cpp
+++ b/js/src/vm/JSAtomUtils.cpp
@@ -16,8 +16,6 @@
 #include <iterator>
 #include <string.h>
 
-#include "util/ToCharsCompat.h"  // MONGODB MODIFICATION: MONGO_MOZJS_TO_CHARS
-
 #include "jstypes.h"
 
 #include "frontend/CompilationStencil.h"
@@ -28,6 +26,7 @@
 #include "js/friend/ErrorMessages.h"  // js::GetErrorMessage, JSMSG_*
 #include "js/Symbol.h"
 #include "util/Text.h"
+#include "util/ToCharsCompat.h"  // MONGODB MODIFICATION: MONGO_MOZJS_TO_CHARS
 #include "vm/JSContext.h"
 #include "vm/JSObject.h"
 #include "vm/StaticStrings.h"

--- a/js/src/vm/TypedArrayObject.cpp
+++ b/js/src/vm/TypedArrayObject.cpp
@@ -28,8 +28,6 @@
 #endif
 #include <type_traits>
 
-#include "util/ToCharsCompat.h"  // MONGODB MODIFICATION: MONGO_MOZJS_TO_CHARS
-
 #include "jsnum.h"
 #include "jstypes.h"
 
@@ -49,6 +47,7 @@
 #include "util/DifferentialTesting.h"
 #include "util/StringBuilder.h"
 #include "util/Text.h"
+#include "util/ToCharsCompat.h"  // MONGODB MODIFICATION: MONGO_MOZJS_TO_CHARS
 #include "util/WindowsWrapper.h"
 #include "vm/ArrayBufferObject.h"
 #include "vm/Float16.h"


### PR DESCRIPTION
Follow-up to PR #6. Moves `#include "util/ToCharsCompat.h"` to its correct alphabetical position in each file to satisfy `check_spidermonkey_style.py` during `extract.sh` build.