### PR TITLE
SERVER-124958 Guard JSContext::onOutOfMemory against null commonNames

### DIFF
--- a/js/src/vm/JSContext.cpp
+++ b/js/src/vm/JSContext.cpp
@@ -279,7 +279,16 @@ void JSContext::onOutOfMemory() {
 
   // If we OOM early in process startup, this may be unavailable so just return
   // instead of crashing unexpectedly.
-  if (MOZ_UNLIKELY(!runtime()->hasInitializedSelfHosting())) {
+  //
+  // MONGODB MODIFICATION: `hasInitializedSelfHosting()` returns true as soon as
+  // `initSelfHostingStencil` completes, but `commonNames` (and therefore the
+  // `out_of_memory_` atom dereferenced below via `names()`) is not set up until
+  // partway through `initializeAtoms`, which runs next. Any OOM during that
+  // window would dereference a null `commonNames` here and take the process
+  // down. Also short-circuit on !commonNames so startup-path OOMs surface as a
+  // clean allocation failure instead of a segfault.
+  if (MOZ_UNLIKELY(!runtime()->hasInitializedSelfHosting() ||
+                   !runtime()->commonNames)) {
     return;
   }
 


### PR DESCRIPTION
`hasInitializedSelfHosting()` returns true as soon as `initSelfHostingStencil` completes, but `commonNames` (dereferenced below via `names()`) is not assigned until partway through `initializeAtoms`, which runs next. An OOM landing in that window passed the existing guard and null-dereferenced `commonNames`, resulting in a SIGSEGV.

Widen the short-circuit so startup-path OOMs during atoms init surface as a clean allocation failure instead of a segfault.