### PR TITLE
SERVER-126049: Use thread-local counter for mmap bytes

### DIFF
--- a/js/public/Utility.h
+++ b/js/public/Utility.h
@@ -49,7 +49,8 @@ extern MOZ_NORETURN MOZ_COLD JS_PUBLIC_API void JS_Assert(const char* s,
  */
 namespace mongo {
 namespace sm {
-JS_PUBLIC_API void check_oom_on_mmap_allocation(size_t bytes);
+JS_PUBLIC_API void record_mmap_alloc(size_t bytes);
+JS_PUBLIC_API void record_mmap_free(size_t bytes);
 }  // namespace sm
 }  // namespace mongo
 

--- a/js/src/gc/Memory.cpp
+++ b/js/src/gc/Memory.cpp
@@ -1143,13 +1143,13 @@ void RecordMemoryAlloc(size_t bytes) {
   MOZ_ASSERT(bytes);
   MOZ_ASSERT((bytes % pageSize) == 0);
 
-  // MONGODB MODIFICATION: Check whether this allocation took us over a
-  // configured memory limit. This may trigger OOM in the background, but we
-  // allow the mozjs logic to proceed normally for now
-  mongo::sm::check_oom_on_mmap_allocation(bytes);
-
   gMappedMemorySizeBytes += bytes;
   gMappedMemoryOperations++;
+
+  // MONGODB MODIFICATION: Update memory bookkeeping. This may check whether the
+  // allocation took us over a configured memory limit and trigger OOM in the
+  // background. Either way, we allow the allocation to proceed normally for now
+  mongo::sm::record_mmap_alloc(bytes);
 }
 
 void RecordMemoryFree(size_t bytes) {
@@ -1159,6 +1159,9 @@ void RecordMemoryFree(size_t bytes) {
 
   gMappedMemorySizeBytes -= bytes;
   gMappedMemoryOperations++;
+
+  // MONGODB MODIFICATION: Update memory bookkeeping
+  mongo::sm::record_mmap_free(bytes);
 }
 
 JS_PUBLIC_API ProfilerMemoryCounts GetProfilerMemoryCounts() {

--- a/js/src/util/Utility.cpp
+++ b/js/src/util/Utility.cpp
@@ -98,7 +98,8 @@ void InitLargeAllocLimit() {
 // allocator implementation in mongo_sources.
 #ifndef JS_USE_CUSTOM_ALLOCATOR
 
-JS_PUBLIC_API void mongo::sm::check_oom_on_mmap_allocation(size_t bytes) {}
+JS_PUBLIC_API void mongo::sm::record_mmap_alloc(size_t bytes) {}
+JS_PUBLIC_API void mongo::sm::record_mmap_free(size_t bytes) {}
 
 JS_PUBLIC_DATA arena_id_t js::MallocArena;
 JS_PUBLIC_DATA arena_id_t js::BackgroundMallocArena;


### PR DESCRIPTION
Define new mmap memory tracking interface for jscustomallocator.

Majority of logical changes are in mongodb PR:  https://github.com/10gen/mongo/pull/53369 